### PR TITLE
Style/OpMethod updated cop name to Naming/BinaryOperatorParameter

### DIFF
--- a/config/rubocop_default.yml
+++ b/config/rubocop_default.yml
@@ -181,7 +181,7 @@ Lint/HandleExceptions:
     or suppressing LoadError for optional dependencies
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameter:
   Description: >-
     This is just silly. Calling the argument `other` in all cases makes no sense.
   Enabled: false


### PR DESCRIPTION
initially reported by @bytnar:


in Rails 5.1 I got in Teamcity 
```
[14:21:15][Step 2/2] RuboCop::ValidationError: The `Style/OpMethods` cop has been renamed and moved to `Naming/BinaryOperatorParameter`.
[14:21:15][Step 2/2] (obsolete configuration found in /usr/local/bundle/bundler/gems/ah-feng_shui-e82f544f448e/config/rubocop_default.yml, please update it)
```