### PR TITLE
Exclude Rails/FilePath cop on specs

### DIFF
--- a/config/rubocop_default.yml
+++ b/config/rubocop_default.yml
@@ -39,6 +39,10 @@ Rails:
 Rails/HttpPositionalArguments:
   Enabled: false
 
+Rails/FilePath:
+  Exclude:
+    spec/**.rb
+
 Metrics/LineLength:
   Description: >-
     Commonly used screens these days easily fit more than 80 characters.


### PR DESCRIPTION
http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/FilePath
disable this cop on specs
it's used to include resources for tests... which makes sense and splitting into separtate params would make code unnecessary cluttered