### PR TITLE
Disable `Style/StringLiterals` lint.

### DIFF
--- a/config/rubocop_default.yml
+++ b/config/rubocop_default.yml
@@ -207,3 +207,7 @@ Style/SymbolArray:
     This cop breaks RoR convention for restricting routes in config/routes.rb with [:regular, :array, :of, :symbols].
   Exclude:
     - 'config/routes.rb'
+
+Style/StringLiterals:
+  Description: This lint doesn't make code better.
+  Enabled: false


### PR DESCRIPTION
I don't believe code `full_name = 'Developer Developerski'` is better than `full_name = "Developer Developerski"`. For me personally it is big pain in the ass many AirHelp project has big adoption of mixed style of defining string and I hope no developer will "invest" time in fixing it.