### PR TITLE
`Style/OpMethod` was renamed in recent version of Rubocop.

### DIFF
--- a/config/rubocop_default.yml
+++ b/config/rubocop_default.yml
@@ -187,7 +187,7 @@ Lint/HandleExceptions:
     or suppressing LoadError for optional dependencies
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Description: >-
     This is just silly. Calling the argument `other` in all cases makes no sense.
   Enabled: false


### PR DESCRIPTION
This causes that pronto build is failing https://teamcity2017.ahinternal.net/viewLog.html?buildId=32820&buildTypeId=Automated_Tests_Webapp_RunFengShuiInDocker&tab=buildLog&_focus=735