### PR TITLE
Disable `Capybara/FeatureMethods` lint.

### DIFF
--- a/config/rubocop_default.yml
+++ b/config/rubocop_default.yml
@@ -211,3 +211,10 @@ Style/SymbolArray:
 Style/StringLiterals:
   Description: This lint doesn't make code better.
   Enabled: false
+
+Capybara/FeatureMethods:
+  Description: >-
+    This lint enforces using statements like `let` and `before` within Capybara feature specs,
+    when Capybara encourage to use its own DSL for creating descriptive acceptance tests.
+    Those are `background`, `feature`, `background`, `scenario` & `given`.
+  Enabled: false


### PR DESCRIPTION
>    This lint enforces using statements like `let` and `before` within Capybara feature specs,
>    when Capybara encourage to use its own DSL for creating descriptive acceptance tests.
>    Those are `background`, `feature`, `background`, `scenario` & `given`.

I believe we use Capybara DSL within AirHelp, so I do not see much value in enforcing "rspec-style" within Capybara feature specs.