### PR TITLE
Disable `Capybara/FeatureMethods` for Rubocop 0.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then install the gem locally:
 $ bundle
 ```
 
-Note: you propably need to install cmake for this to work
+Note: you probably need to install cmake for this to work
 
 ```bash
 $ brew install cmake
@@ -44,9 +44,9 @@ inherit_gem:
   ah-feng_shui:
     - config/rubocop_default.yml
 ```
-It can also contain project specific rules to tweeak rubocop for special project needs.
+It can also contain project specific rules to tweak Rubocop for special project needs.
 
-For **Rails 5.1** and above use `rubocop_default_rails_5.1.yml`
+For **Rubocop 0.51** and above use `rubocop_default_rails_5.1.yml`
 
 #### Usage
 
@@ -63,7 +63,7 @@ $ bundle exec pronto run -r rubocop
 
 ### Reek
 
-Copy `config/config-rails.reek` into your project root directory and tweek as needed.
+Copy `config/config-rails.reek` into your project root directory and tweak as needed.
 
 #### Usage
 

--- a/config/rubocop_default.yml
+++ b/config/rubocop_default.yml
@@ -211,10 +211,3 @@ Style/SymbolArray:
 Style/StringLiterals:
   Description: This lint doesn't make code better.
   Enabled: false
-
-Capybara/FeatureMethods:
-  Description: >-
-    This lint enforces using statements like `let` and `before` within Capybara feature specs,
-    when Capybara encourage to use its own DSL for creating descriptive acceptance tests.
-    Those are `background`, `feature`, `background`, `scenario` & `given`.
-  Enabled: false

--- a/config/rubocop_default_rails_5.1.yml
+++ b/config/rubocop_default_rails_5.1.yml
@@ -201,3 +201,10 @@ Style/FrozenStringLiteralComment:
     fix the offenses and enable this cop if we decide to use frozen string litterals in
     the future.
   Enabled: false
+
+Capybara/FeatureMethods:
+  Description: >-
+    This lint enforces using statements like `let` and `before` within Capybara feature specs,
+    when Capybara encourage to use its own DSL for creating descriptive acceptance tests.
+    Those are `background`, `feature`, `background`, `scenario` & `given`.
+  Enabled: false


### PR DESCRIPTION
I did it in a wrong file, `rubocop_default_rails_5.1.yml` is a **very** confusing name, `rails` should be removed from it IMO.