### PR TITLE
Add enabled envs for Rubocop Rails/UnknownEnv

### DIFF
--- a/config/rubocop_default_rails_5.1.yml
+++ b/config/rubocop_default_rails_5.1.yml
@@ -208,3 +208,11 @@ Capybara/FeatureMethods:
     when Capybara encourage to use its own DSL for creating descriptive acceptance tests.
     Those are `background`, `feature`, `background`, `scenario` & `given`.
   Enabled: false
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - integration
+    - staging
+    - production


### PR DESCRIPTION
Rubocop complains with Rails/UnknownEnv when doing: `if Rails.env.integration?` because default it only supports only `development, test, production`

https://github.com/bbatsov/rubocop/issues/4956