### PR TITLE
Disable context wording cop

### DIFF
--- a/config/rubocop_default_rails_5.1.yml
+++ b/config/rubocop_default_rails_5.1.yml
@@ -216,3 +216,9 @@ Rails/UnknownEnv:
     - integration
     - staging
     - production
+
+RSpec/ContextWording:
+  Description: >-
+    We want to have our contexts described freely, we want to use `and` and other starting words instead of
+    basic `when`, `with`, `without` this cop forces
+  Enabled: false


### PR DESCRIPTION
This is really silly cop:

```
RSpec/ContextWording: Start context description with 'when', 'with', or 'without'. (http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)
```