### PR TITLE
Disable `RSpec/PredicateMatcher` Rubocop lint

### DIFF
--- a/config/rubocop_default_rails_5.1.yml
+++ b/config/rubocop_default_rails_5.1.yml
@@ -220,5 +220,16 @@ Rails/UnknownEnv:
 RSpec/ContextWording:
   Description: >-
     We want to have our contexts described freely, we want to use `and` and other starting words instead of
-    basic `when`, `with`, `without` this cop forces
+    basic `when`, `with`, `without` this cop forces.
+  Enabled: false
+
+RSpec/PredicateMatcher:
+  Description: >-
+    This lint enforces using predicate matcher over using predicate method directly.
+      bad  -> expect(claim.eligible?).to be_truthy
+      good -> expect(claim).to be_eligible
+    Let's consider another example though:
+      bad  -> expect(mailbox.was_scan_completed?).to be_truthy
+      good -> expect(mailbox).to be_was_completed
+    Does it improve anything? I don't think so.
   Enabled: false


### PR DESCRIPTION
I provided some reasoning/explanation directly in the config file. Full description can be found here: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher