### PR TITLE
Disable RSpec/ExpectInhook cop.

### DIFF
--- a/config/rubocop_default.yml
+++ b/config/rubocop_default.yml
@@ -74,6 +74,9 @@ RSpec/LetSetup:
 RSpec/MessageSpies:
   EnforcedStyle: 'receive'
 
+RSpec/ExpectInHook:
+  Enabled: false
+
 Metrics/ClassLength:
   Description: >-
     Try to keep classes small

--- a/config/rubocop_default_rails_5.1.yml
+++ b/config/rubocop_default_rails_5.1.yml
@@ -74,6 +74,9 @@ RSpec/LetSetup:
 RSpec/MessageSpies:
   EnforcedStyle: 'receive'
 
+RSpec/ExpectInHook:
+  Enabled: false
+
 Metrics/ClassLength:
   Description: >-
     Try to keep classes small


### PR DESCRIPTION
We have plenty of code which uses `expect` in `before` hook. Thanks to this there will be no more

```
spec/models/itinerary_flight_spec.rb:200 W: RSpec/ExpectInHook: Do not use `expect` in `before` hook (http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook)
```