### PR TITLE
Fix project link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In your `Gemfile` add:
 ```ruby
 group :test do
   # Configuration for pronto
-  gem 'ah-feng_shui', git: 'github.com/AirHelp/ah-feng_shui', branch: 'master'
+  gem 'ah-feng_shui', git: 'https://github.com/AirHelp/ah-feng_shui', branch: 'master'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This repository is one place for common resources needed with static code analyz
 
 ## Installation
 
+Preferred way:
+In your `Gemfile` add all the feng-shui dependencies, without actually using this gem. 
+Example can be found [here](https://github.com/AirHelp/ah-mama/pull/183/files#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R84).
+
+The old way:
 In your `Gemfile` add:
 
 ```ruby


### PR DESCRIPTION
Since 
```gem 'ah-feng_shui', git: 'github.com/AirHelp/ah-feng_shui', branch: 'master'``` 

put into Gemfile in my project was giving me 

`fatal: repository 'github.com/AirHelp/ah-feng_shui.git' does not exist` 

I was wondering whether my git creds we broken again but not this time! 
All it was missing `https://`, and adding it would make everything automagically work again ✨ 
Updating README for any other lost soul out there. 