### PR TITLE
[AIR-26217] Added rubocop-performance dependency

### DIFF
--- a/ah-feng_shui.gemspec
+++ b/ah-feng_shui.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
 
   # Other
   spec.add_runtime_dependency 'rubocop-rspec'
+  spec.add_runtime_dependency 'rubocop-performance'
 end

--- a/config/rubocop_default_rails_5.0.yml
+++ b/config/rubocop_default_rails_5.0.yml
@@ -2,7 +2,10 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
 # Run 'gem install rubocop-rspec' if you want to use rubocop-rspec
-require: rubocop-rspec
+# Run 'gem install rubocop-performance' if you want to use rubocop-performance
+require:
+  - 'rubocop-rspec'
+  - 'rubocop-performance'
 
 AllCops:
   # Exclude anything that isn't really part of our code.

--- a/lib/ah/feng_shui/version.rb
+++ b/lib/ah/feng_shui/version.rb
@@ -1,5 +1,5 @@
 module Ah
   module FengShui
-    VERSION = '0.1.8'.freeze
+    VERSION = '0.1.9'.freeze
   end
 end


### PR DESCRIPTION
`rubocop-performance` is an extracted gem and includes related cops. I've included it in rails5.0 config (which servers for Rails >5).

Version bumped from 0.18.0 to 0.19.0